### PR TITLE
add transform data functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,24 @@ UMAP can use a precomputed distance matrix instead of finding the nearest neighb
 embedding = umap(distances, n_components; metric=:precomputed)
 ```
 
+## Fitting UMAP to a dataset and transforming new data
+To transform new data with UMAP fit to a dataset, use the `ref_embedding` parameter.
+```jl
+embedding = umap(X, n_components, ref_embedding; <kwargs>)
+```
+`ref_embedding` is a matrix of shape (`n_components`, R reference points). The R reference points correspond to the first R samples (columns) of `X`, which are the fit data, and the remaining samples of `X` are the data to transform with respect to the fit data. For example, `ref_embedding` may be the output of `umap` called on the first R samples of `X`.
+
+The output of this transformation will be a matrix of embedded points, where the first R points are the points from `ref_embedding`, and the remaining R points are the embedded points of the transformed samples.
+
+The number of reference samples R must be less than the number of samples in `X`. The keyword arguments `kwargs` are the same as normal `umap` usage, but transforming new data according to fit data is only well defined when using the same `kwargs` as the fit data.
+
+
 ## Implementation Details
 There are two main steps involved in UMAP: building a weighted graph with edges connecting points to their nearest neighbors, and optimizing the low-dimensional embedding of that graph. The first step is accomplished either by an exact kNN search (for datasets with `< 4096` points) or by the approximate kNN search algorithm, [NNDescent](https://github.com/dillondaudert/NearestNeighborDescent.jl). This step is also usually the most costly.
 
 The low-dimensional embedding is initialized (by default) with the eigenvectors of the normalized Laplacian of the kNN graph. These are found using ARPACK (via [Arpack.jl](https://github.com/JuliaLinearAlgebra/Arpack.jl)).
 
 ## Current Limitations
-- **No transform**: Only one-time embeddings are possible at the moment. That is to say, it isn't possible to "fit" UMAP to a dataset and then use it to "transform" new data
 - **Input data types**: Only data points that are represented by vectors of numbers (passed in as a matrix) are valid inputs. This is mostly due to a lack of support for other formats in [NNDescent](https://github.com/dillondaudert/NearestNeighborDescent.jl). Support for e.g. string datasets is possible in the future
 - **Sequential**: This implementation does not take advantage of any parallelism
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ model.dists     # The distances of the neighbors indicated by model.knns
 ### Embedding new data
 To transform new data into the existing embedding of a UMAP model, use the `umap_transform` function:
 ```jl
-Q_embedding = umap_transform(Q, model; <kwargs>)
+Q_embedding = umap_transform(model, Q; <kwargs>)
 ```
 where `Q` is a matrix of new query data to embed into the existing embedding, and `model` is the object obtained from the `UMAP_` call above. `Q` must come from a space of the same dimensionality as `model.data` (ie `X` in the `UMAP_` call above).
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ embedding = umap(X, n_components, ref_embedding; <kwargs>)
 ```
 `ref_embedding` is a matrix of shape (`n_components`, R reference points). The R reference points correspond to the first R samples (columns) of `X`, which are the fit data, and the remaining samples of `X` are the data to transform with respect to the fit data. For example, `ref_embedding` may be the output of `umap` called on the first R samples of `X`.
 
+Here is an example process of fitting training and transforming testing data:
+
+```jl
+Xfit =       ...  # some training data of size (n_features, k_samples)
+ref_embedding = umap(Xfit, 2)
+
+Xtransform = ...  # some testing data of size (n_features, k_samples)
+Xall = hcat(Xfit, Xtransform)
+total_embedding = umap(Xall, 2, ref_embedding)
+
+ref_inds = [1:size(ref_embedding, 2)...]
+query_inds = [1+size(ref_embedding, 2):size(total_embedding, 2)...]
+transform_embedding = total_embedding[:, query_inds]
+@assert ref_embedding == total_embedding[:, ref_inds]
+```
+
 The output of this transformation will be a matrix of embedded points, where the first R points are the points from `ref_embedding`, and the remaining R points are the embedded points of the transformed samples.
 
 The number of reference samples R must be less than the number of samples in `X`. The keyword arguments `kwargs` are the same as normal `umap` usage, but transforming new data according to fit data is only well defined when using the same `kwargs` as the fit data.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ model.dists     # The distances of the neighbors indicated by model.knns
 ```
 
 ### Embedding new data
-To transform new data into the existing embedding of a UMAP model, use the `umap_transform` function:
+To transform new data into the existing embedding of a UMAP model, use the `transform` function:
 ```jl
-Q_embedding = umap_transform(model, Q; <kwargs>)
+Q_embedding = transform(model, Q; <kwargs>)
 ```
 where `Q` is a matrix of new query data to embed into the existing embedding, and `model` is the object obtained from the `UMAP_` call above. `Q` must come from a space of the same dimensionality as `model.data` (ie `X` in the `UMAP_` call above).
 

--- a/src/UMAP.jl
+++ b/src/UMAP.jl
@@ -11,6 +11,6 @@ include("utils.jl")
 include("embeddings.jl")
 include("umap_.jl")
 
-export umap, UMAP_
+export umap, UMAP_, umap_transform
 
 end # module

--- a/src/UMAP.jl
+++ b/src/UMAP.jl
@@ -11,6 +11,6 @@ include("utils.jl")
 include("embeddings.jl")
 include("umap_.jl")
 
-export umap, UMAP_, umap_transform
+export umap, UMAP_, transform
 
 end # module

--- a/src/embeddings.jl
+++ b/src/embeddings.jl
@@ -111,7 +111,7 @@ function optimize_embedding(graph,
 end
 
 """
-    optimize_embedding_rq(graph, embedding,query_inds, ref_inds, n_epochs, initial_alpha, min_dist, spread, gamma, neg_sample_rate, _a=nothing, _b=nothing, move_ref=false) -> embedding
+    optimize_embedding_rq(graph, embedding,query_inds, ref_inds, n_epochs, initial_alpha, min_dist, spread, gamma, neg_sample_rate, _a, _b; move_ref=false) -> embedding
 
 Optimize an embedding by minimizing the fuzzy set cross entropy between the high and low dimensional simplicial sets using stochastic gradient descent.
 Optimize "query" samples with respect to "reference" samples.
@@ -124,7 +124,11 @@ Optimize "query" samples with respect to "reference" samples.
 - `n_epochs`: the number of training epochs for optimization
 - `initial_alpha`: the initial learning rate
 - `gamma`: the repulsive strength of negative samples
-- `neg_sample_rate::Integer`: the number of negative samples per positive sample
+- `neg_sample_rate`: the number of negative samples per positive sample
+- `_a`: this controls the embedding. If the actual argument is `nothing`, this is determined automatically by `min_dist` and `spread`.
+- `_b`: this controls the embedding. If the actual argument is `nothing`, this is determined automatically by `min_dist` and `spread`.
+
+# Keyword Arguments
 - `move_ref::Bool = false`: if true, also improve the embeddings of samples in `ref_inds`, else fix them and only improve embeddings of samples in `query_inds`.
 """
 function optimize_embedding(graph,

--- a/src/embeddings.jl
+++ b/src/embeddings.jl
@@ -20,6 +20,28 @@ function initialize_embedding(graph::AbstractMatrix{T}, n_components, ::Val{:ran
 end
 
 """
+    initialize_embedding(graph, ref_embedding, query_inds::Vector{<:Integer}, ref_inds::Vector{<:Integer}) -> embedding
+
+Initialize an embedding of points corresponding to the `query_inds` columns of the `graph`, by taking weighted means of
+the `ref_embedding`, where weights are values from the `ref_inds` rows of the `graph`.
+
+`ref_inds[i]` is the row in the `graph` corresponding to the `i`th sample of `ref_embedding`, 
+ie. the sample `ref_embedding[:, i]`.
+
+The resulting embedding will have shape `(size(ref_embedding, 1), length(query_inds))`, where `size(ref_embedding, 1)`
+is the number of components (dimensions) of the `reference embedding`, and `length(query_inds)` is the number of 
+samples in the resulting embedding.
+"""
+function initialize_embedding(graph, ref_embedding, query_inds::Vector{<:Integer}, ref_inds::Vector{<:Integer})
+    embed = [zeros(size(ref_embedding, 1)) for _ in 1:length(query_inds)]
+    rq_graph = graph[ref_inds, query_inds]
+    for (i, col) in enumerate(eachcol(rq_graph))
+        embed[i] = vec(sum(transpose(col) .* ref_embedding, dims=2) ./ sum(col))
+    end
+    return embed
+end
+
+"""
     spectral_layout(graph, embed_dim) -> embedding
 
 Initialize the graph layout with spectral embedding.
@@ -68,13 +90,67 @@ function optimize_embedding(graph,
                             neg_sample_rate,
                             _a=nothing,
                             _b=nothing)
+    # query_inds and ref_inds are each the entire set of indices of the embedding, so all samples of the embedding will
+    #   be optimized, with respect to each (neighbor) sample.
+    query_inds = ref_inds = collect(eachindex(embedding))
+    return optimize_embedding(
+        graph,
+        embedding,
+        query_inds,
+        ref_inds,
+        n_epochs,
+        initial_alpha,
+        min_dist,
+        spread,
+        gamma,
+        neg_sample_rate,
+        _a,
+        _b,
+        move_ref=true
+    )
+end
+
+"""
+    optimize_embedding_rq(graph, embedding,query_inds, ref_inds, n_epochs, initial_alpha, min_dist, spread, gamma, neg_sample_rate, _a=nothing, _b=nothing, move_ref=false) -> embedding
+
+Optimize an embedding by minimizing the fuzzy set cross entropy between the high and low dimensional simplicial sets using stochastic gradient descent.
+Optimize "query" samples with respect to "reference" samples.
+
+# Arguments
+- `graph`: a sparse matrix of shape (n_samples, n_samples)
+- `embedding`: a vector of length (n_samples,) of vectors representing the embedded data points
+- `query_inds`: the indices of the embedding to optimize.
+- `ref_inds`: the indices of the embedding to optimize with respect to.
+- `n_epochs`: the number of training epochs for optimization
+- `initial_alpha`: the initial learning rate
+- `gamma`: the repulsive strength of negative samples
+- `neg_sample_rate::Integer`: the number of negative samples per positive sample
+- `move_ref::Bool = false`: if true, also improve the embeddings of samples in `ref_inds`, else fix them and only improve embeddings of samples in `query_inds`.
+"""
+function optimize_embedding(graph,
+                            embedding,
+                            query_inds,
+                            ref_inds,
+                            n_epochs,
+                            initial_alpha,
+                            min_dist,
+                            spread,
+                            gamma,
+                            neg_sample_rate,
+                            _a,
+                            _b;
+                            move_ref::Bool=false)
     a, b = fit_ab(min_dist, spread, _a, _b)
+    ref_indset = Set(ref_inds)
 
     alpha = initial_alpha
     for e in 1:n_epochs
-        @inbounds for i in 1:size(graph, 2)
+        @inbounds for i in query_inds
             for ind in nzrange(graph, i)
                 j = rowvals(graph)[ind]
+                if !(j in ref_indset)
+                    continue
+                end
                 p = nonzeros(graph)[ind]
                 if rand() <= p
                     sdist = evaluate(SqEuclidean(), embedding[i], embedding[j])
@@ -86,11 +162,13 @@ function optimize_embedding(graph,
                     @simd for d in eachindex(embedding[i])
                         grad = clamp(delta * (embedding[i][d] - embedding[j][d]), -4, 4)
                         embedding[i][d] += alpha * grad
-                        embedding[j][d] -= alpha * grad
+                        if move_ref
+                            embedding[j][d] -= alpha * grad
+                        end
                     end
 
                     for _ in 1:neg_sample_rate
-                        k = rand(1:size(graph, 2))
+                        k = rand(ref_inds)
                         i != k || continue
                         sdist = evaluate(SqEuclidean(), embedding[i], embedding[k])
                         if sdist > 0
@@ -107,12 +185,10 @@ function optimize_embedding(graph,
                             embedding[i][d] += alpha * grad
                         end
                     end
-
                 end
             end
         end
         alpha = initial_alpha*(1 - e//n_epochs)
     end
-
     return embedding
 end

--- a/src/umap_.jl
+++ b/src/umap_.jl
@@ -162,7 +162,6 @@ function umap_transform(Q::AbstractMatrix{S},
                         ) where {S<:Real}
     # argument checking
     size(Q, 2) > n_neighbors > 0                     || throw(ArgumentError("size(Q, 2) must be greater than n_neighbors and n_neighbors must be greater than 0"))
-    n_epochs > 0                                     || throw(ArgumentError("n_epochs must be greater than 0"))
     learning_rate > 0                                || throw(ArgumentError("learning_rate must be greater than 0"))
     min_dist > 0                                     || throw(ArgumentError("min_dist must be greater than 0"))
     0 ≤ set_operation_ratio ≤ 1                      || throw(ArgumentError("set_operation_ratio must lie in [0, 1]"))
@@ -172,7 +171,7 @@ function umap_transform(Q::AbstractMatrix{S},
     size(model.data, 1) == size(Q, 1)                || throw(ArgumentError("size(model.data, 1) must equal size(Q, 1)"))
 
 
-    
+    n_epochs = max(0, n_epochs)
     # main algorithm
     knns, dists = knn_search(model.data, Q, n_neighbors, metric, model.knns, model.dists)
     graph = fuzzy_simplicial_set(knns, dists, n_neighbors, size(model.data, 2), local_connectivity, set_operation_ratio, false)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,8 +43,8 @@ the approximate nearest neighbors graph; otherwise, reconstruct it from scratch.
 If the matrices are small, search for exact nearest neighbors of `Q` by computing all pairwise distances with `X`.
 
 # Returns
-- `knns` - `knns[j, i]` is the index of node i's jth nearest neighbor.
-- `dists` - `dists[j, i]` is the distance of node i's jth nearest neighbor.
+- `knns`: `knns[j, i]` is the index of node i's jth nearest neighbor.
+- `dists`: `dists[j, i]` is the distance of node i's jth nearest neighbor.
 """
 function knn_search end
 
@@ -97,7 +97,7 @@ function knn_search(X::AbstractMatrix,
                     dists::AbstractMatrix{<:Real})
     
     if size(X, 2) < 4096
-        return _knn_from_dists(pairwise(metric, X, Q, dims=2), k)
+        return _knn_from_dists(pairwise(metric, X, Q, dims=2), k, ignore_diagonal=false)
     end
 
     if isempty(knns) || isempty(dists) || size(knns) != size(dists) || size(knns, 1) < k

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -95,17 +95,17 @@ function knn_search(X::AbstractMatrix,
                     metric::SemiMetric,
                     knns::AbstractMatrix{<:Integer},
                     dists::AbstractMatrix{<:Real})
-    
+
     if size(X, 2) < 4096
         return _knn_from_dists(pairwise(metric, X, Q, dims=2), k, ignore_diagonal=false)
     end
 
-    if isempty(knns) || isempty(dists) || size(knns) != size(dists) || size(knns, 1) < k
+    if isempty(knns) || isempty(dists) || size(knns) != size(dists)
         knngraph = nndescent(X, k, metric)
     else
         knngraph = HeapKNNGraph(collect(eachcol(X)), metric, knns, dists)
     end
-    return search(knngraph, collect(eachcol(Q)), k)
+    return search(knngraph, collect(eachcol(Q)), k; max_candidates=8*k)
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,22 +22,38 @@ function fit_ab(min_dist, spread, ::Nothing, ::Nothing)
     return a, b
 end
 
-knn_search(dist_mat, k, metric::Symbol) = knn_search(dist_mat, k, Val(metric))
 
 """
-    knn_search(dist_mat, k, :precomputed) -> knns, dists
+    knn_search(X::AbstractMatrix, k::Integer, metric)                                -> knns, dists
+    knn_search(X::AbstractMatrix, Q::AbstractMatrix, k::Integer, metric::SemiMetric,
+                    knns::AbstractMatrix{<:Integer}, dists::AbstractMatrix{<:Real})  -> knns, dists,
 
-Find the `k` nearest neighbors of each point in a precomputed distance
-matrix.
-"""
-knn_search(dist_mat, k, ::Val{:precomputed}) = _knn_from_dists(dist_mat, k)
+Find the `k` nearest neighbors of each point.
 
-"""
-    knn_search(X, k, metric) -> knns, dists
+`metric` may be of type:
+- ::Symbol - `knn_search` is dispatched to one of the following based on the evaluation of `metric`:
+- ::Val(:precomputed) - computes neighbors from `X` treated as a precomputed distance matrix.
+- ::SemiMetric - computes neighbors from `X` treated as samples, using the given metric.
 
-Find the `k` nearest neighbors of each point in `X` by `metric`.
+Given a matrix `X` and a matrix `Q`, use the given metric to compute the `k` nearest neighbors out of the
+columns of `X` from the queries (columns in `Q`). 
+If the matrices are large, compute the approximate nearest neighbors graph of `X` and use this to search 
+for approximate nearest neighbors of `Q`. If provided `knns` and `dists` are nonempty, use these to reconstruct 
+the approximate nearest neighbors graph; otherwise, reconstruct it from scratch.
+If the matrices are small, search for exact nearest neighbors of `Q` by computing all pairwise distances with `X`.
+
+# Returns
+- `knns` - `knns[j, i]` is the index of node i's jth nearest neighbor.
+- `dists` - `dists[j, i]` is the distance of node i's jth nearest neighbor.
 """
-function knn_search(X,
+function knn_search end
+
+knn_search(X::AbstractMatrix, k::Integer, metric::Symbol) = knn_search(X, k, Val(metric))
+
+# treat given matrix `X` as distance matrix
+knn_search(X::AbstractMatrix, k::Integer, ::Val{:precomputed}) = _knn_from_dists(X, k)
+
+function knn_search(X::AbstractMatrix,
                     k,
                     metric::SemiMetric)
     if size(X, 2) < 4096
@@ -50,11 +66,15 @@ end
 # compute all pairwise distances
 # return the nearest k to each point v, other than v itself
 function knn_search(X::AbstractMatrix{S},
-                    k,
+                    k::Integer,
                     metric,
                     ::Val{:pairwise}) where {S <: Real}
     num_points = size(X, 2)
-    dist_mat = Array{S}(undef, num_points, num_points)
+    if S <: AbstractFloat
+        dist_mat = Array{S}(undef, num_points, num_points)
+    else
+        dist_mat = Array{Float64}(undef, num_points, num_points)
+    end
     pairwise!(dist_mat, metric, X, dims=2)
     # all_dists is symmetric distance matrix
     return _knn_from_dists(dist_mat, k)
@@ -69,8 +89,31 @@ function knn_search(X::AbstractMatrix{S},
     return knn_matrices(knngraph)
 end
 
-function _knn_from_dists(dist_mat::AbstractMatrix{S}, k) where {S <: Real}
-    knns_ = [partialsortperm(view(dist_mat, :, i), 2:k+1) for i in 1:size(dist_mat, 1)]
+function knn_search(X::AbstractMatrix, 
+                    Q::AbstractMatrix,
+                    k::Integer,
+                    metric::SemiMetric,
+                    knns::AbstractMatrix{<:Integer},
+                    dists::AbstractMatrix{<:Real})
+    
+    if size(X, 2) < 4096
+        return _knn_from_dists(pairwise(metric, X, Q, dims=2), k)
+    end
+
+    if isempty(knns) || isempty(dists) || size(knns) != size(dists) || size(knns, 1) < k
+        knngraph = nndescent(X, k, metric)
+    else
+        knngraph = HeapKNNGraph(collect(eachcol(X)), metric, knns, dists)
+    end
+    return search(knngraph, collect(eachcol(Q)), k)
+end
+
+
+function _knn_from_dists(dist_mat::AbstractMatrix{S}, k::Integer; ignore_diagonal=true) where {S <: Real}
+    # Ignore diagonal 0 elements (which will be smallest) when distance matrix represents pairwise distances of the same set
+    # If dist_mat represents distances between two different sets, diagonal elements be nontrivial
+    range = (1:k) .+ ignore_diagonal
+    knns_ = [partialsortperm(view(dist_mat, :, i), range) for i in 1:size(dist_mat, 2)]
     dists_ = [dist_mat[:, i][knns_[i]] for i in eachindex(knns_)]
     knns = hcat(knns_...)::Matrix{Int}
     dists = hcat(dists_...)::Matrix{S}

--- a/test/umap_tests.jl
+++ b/test/umap_tests.jl
@@ -164,4 +164,14 @@
         end
     end
 
+    @testset "UMAP_ with reference" begin
+        data = rand(5, 50)
+        ref_embedding = rand(2, 20)
+        umap_ = UMAP_(data, 2, ref_embedding)
+        @test umap_ isa UMAP_{Float64}
+        @test size(umap_.graph) == (50, 50)
+        @test size(umap_.embedding) == (2, 50)
+        @test isapprox(umap_.embedding[:, 1:20], ref_embedding)
+    end
+
 end

--- a/test/utils_tests.jl
+++ b/test/utils_tests.jl
@@ -25,6 +25,45 @@
 
         end
 
+        @testset "query data tests" begin
+            X = [0.0 -2.0 0.0; 0.0 -1.0 2.0]
+            Q = [-2 0; 0 -1]
+            true_knns = [2 1; 1 2]
+            true_dists = [1.0 1.0; 2.0 2.0]
+            knns = [3 1 1; 2 3 2]
+            dists = [2.0 2.236 2.0; 2.236 3.606 3.606]
+            ret_knns, ret_dists = knn_search(X, Q, 2, Euclidean(), knns, dists)
+            @test ret_knns == true_knns
+            @test isapprox(ret_dists, true_dists, atol=1e-4)
+        end
+
+        @testset "bad knns and dists values" begin
+            X = [0. 0. 0.; 0. 1.5 2.]
+            Q = [-2 0; 0 -1]
+            true_knns = [1 1; 2 2]
+            true_dists = [2.0 1.0; 2.5 2.5]
+
+            # empty knns / dists
+            knns = Matrix{Int}(undef, 0, 0)
+            dists = Matrix{Float64}(undef, 0, 0)
+            ret_knns, ret_dists = knn_search(X, Q, 2, Euclidean(), knns, dists)
+            @test true_knns == ret_knns
+            @test isapprox(true_dists, ret_dists, atol=1e-4)
+
+            # different size knns / dists
+            knns = rand(1:3, 2, 2)
+            dists = rand(2, 3)
+            ret_knns, ret_dists = knn_search(X, Q, 2, Euclidean(), knns, dists)
+            @test true_knns == ret_knns
+            @test isapprox(true_dists, ret_dists, atol=1e-4)
+
+            # knns / dists smaller than k
+            knns = [2 3 2]
+            dists = [1.5 .5 .5]
+            ret_knns, ret_dists = knn_search(X, Q, 2, Euclidean(), knns, dists)
+            @test true_knns == ret_knns
+            @test isapprox(true_dists, ret_dists, atol=1e-4)
+        end
     end
 
     @testset "combine_fuzzy_sets tests" begin

--- a/test/utils_tests.jl
+++ b/test/utils_tests.jl
@@ -36,34 +36,6 @@
             @test ret_knns == true_knns
             @test isapprox(ret_dists, true_dists, atol=1e-4)
         end
-
-        @testset "bad knns and dists values" begin
-            X = [0. 0. 0.; 0. 1.5 2.]
-            Q = [-2 0; 0 -1]
-            true_knns = [1 1; 2 2]
-            true_dists = [2.0 1.0; 2.5 2.5]
-
-            # empty knns / dists
-            knns = Matrix{Int}(undef, 0, 0)
-            dists = Matrix{Float64}(undef, 0, 0)
-            ret_knns, ret_dists = knn_search(X, Q, 2, Euclidean(), knns, dists)
-            @test true_knns == ret_knns
-            @test isapprox(true_dists, ret_dists, atol=1e-4)
-
-            # different size knns / dists
-            knns = rand(1:3, 2, 2)
-            dists = rand(2, 3)
-            ret_knns, ret_dists = knn_search(X, Q, 2, Euclidean(), knns, dists)
-            @test true_knns == ret_knns
-            @test isapprox(true_dists, ret_dists, atol=1e-4)
-
-            # knns / dists smaller than k
-            knns = [2 3 2]
-            dists = [1.5 .5 .5]
-            ret_knns, ret_dists = knn_search(X, Q, 2, Euclidean(), knns, dists)
-            @test true_knns == ret_knns
-            @test isapprox(true_dists, ret_dists, atol=1e-4)
-        end
     end
 
     @testset "combine_fuzzy_sets tests" begin


### PR DESCRIPTION
This adds functionality to transform data with UMAP with respect to previously fit data.

See the [README additions](https://github.com/dillondaudert/UMAP.jl/compare/master...sanjmohan:feat/transform-data?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8) for usage overview.

First, a skeleton is build for the manifold containing both the old fit data and the new data to transform. This yields a graph whose first R rows/columns correspond to the old fit data (for which an embedding has already been obtained), and the remaining rows/columns correspond to the new data to be transformed. This uses the preexisting `fuzzy_simplicial_set` function as is.

Next, an embedding for the data to transform is initialized as a weighted mean of points from the reference embedding. This is the new method overload for the `initialize_embedding` function. For comparison, [here is the python implementation](https://github.com/lmcinnes/umap/blob/96f1291fb5ba70df18f67fffb588bd7cbcabee5e/umap/umap_.py#L1126) (the weights are obtained from the graph entries, which you can see [here](https://github.com/lmcinnes/umap/blob/96f1291fb5ba70df18f67fffb588bd7cbcabee5e/umap/umap_.py#L2029) ).

Finally, the `optimize_embedding` function operates as before, but only computes attractions / repulsions between the new embedding and the reference embedding. For the python version, see [here](https://github.com/lmcinnes/umap/blob/96f1291fb5ba70df18f67fffb588bd7cbcabee5e/umap/layouts.py#L243) They use `head` to refer to the new embedding, which I designated with `query_inds`, and `tail` to refer to the reference embedding, which I designated with `ref_inds`.

When using this via a high level `umap` call, the reference (fit) data is assumed to be the first R samples of the input data. However, the `optimize_embedding` function can refer to arbitrary indices of the input graph / input embedding as the reference data, and arbitrary indices as the query data (data to be optimized/transformed). These indices don't necessarily have to cover all indices of the graph/embedding (the remaining entries will be ignored entirely). They can also overlap (which means that data may be optimized by computing attractions/repulsions to other data that is also intended to be optimized).

I also added a few basic tests to cover these new features.

Let me know what you think about this addition, or if there are other parts I can clarify (either in this PR or documentation)!