### PR TITLE
modified _knn_from_dists to enable very large distance matrices

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -112,10 +112,12 @@ function _knn_from_dists(dist_mat::AbstractMatrix{S}, k::Integer; ignore_diagona
     # Ignore diagonal 0 elements (which will be smallest) when distance matrix represents pairwise distances of the same set
     # If dist_mat represents distances between two different sets, diagonal elements be nontrivial
     range = (1:k) .+ ignore_diagonal
-    knns_ = [partialsortperm(view(dist_mat, :, i), range) for i in 1:size(dist_mat, 2)]
-    dists_ = [dist_mat[:, i][knns_[i]] for i in eachindex(knns_)]
-    knns = hcat(knns_...)::Matrix{Int}
-    dists = hcat(dists_...)::Matrix{S}
+    knns  = Array{Int,2}(undef,k,size(dist_mat,2))
+    dists = Array{S,2}(undef,k,size(dist_mat,2))
+    for i ∈ 1:size(dist_mat, 2)
+        knns[:,i]  = partialsortperm(dist_mat[ :, i], range)
+        dists[:,i] = dist_mat[knns[:,i],i]
+    end
     return knns, dists
 end
 


### PR DESCRIPTION
This is a simple code modification that has enabled me to use very large distance matrices as input to UMAP (e.g. 100 000 x 100 000 distance matrices). The matrices may be so large that they do not fit into memory unless they are implemented in a sparse way (I have been using `DefaultArrays`; not really the most efficient implementation but it does the job).

The modified code is equivalent to the old one but doesn't seem to require nearly as much memory.

With the older code, julia would run out of memory in the `_knn_from_dists` function while trying to allocate very large matrices. I am not sure why that happened but I guess it is related to how array comprehensions are materialized.

On a side note, modifications I used that are not included in this PR are 
- using `Threads.@threads` in the for loop in `_knn_from_dists`, which provides a great speedup 
- adding a `ProgressMeter` (for when UMAP takes 10 minutes...) in a few functions. 
Those are basic modifications but really improve the quality of life when dealing with large datasets. Let me know if you'd be interested in some of these.
