### PR TITLE
fixes noise added to spectral embedding

### DIFF
--- a/src/embeddings.jl
+++ b/src/embeddings.jl
@@ -6,7 +6,7 @@ function initialize_embedding(graph::AbstractMatrix{T}, n_components, ::Val{:spe
         embed = spectral_layout(graph, n_components)
         # expand
         expansion = 10 / maximum(embed)
-        embed .= (embed .* expansion) .+ (1//10000) .* randn.(T)
+        embed .= (embed .* expansion) .+ (1//10000) .* randn(T, size(embed))
         embed = collect(eachcol(embed))
     catch e
         @info "$e\nError encountered in spectral_layout; defaulting to random layout"


### PR DESCRIPTION
The same (scalar) noise is added to all values in the spectral embedding. Noise should actually be added to every point/coordinate independently.